### PR TITLE
nbest API for getting n-candidates for each node

### DIFF
--- a/src/inference/graph_inference.cpp
+++ b/src/inference/graph_inference.cpp
@@ -381,22 +381,22 @@ public:
       Json::Value* response) override {
     *response = Json::Value(Json::arrayValue);
     
+    std::vector<std::pair<int, double>> scored_candidates;
     for (size_t i = 0; i < assignments_.size(); ++i) {
       if (assignments_[i].must_infer) {
-        std::vector<std::pair<int, double>> scored_candidates;
         GetCandidatesForNode(inference, i, &scored_candidates);
-        Json::Value nodeResults(Json::objectValue);
-        nodeResults["v"] = query_->numberer_.NumberToValue(i);
-        Json::Value nodeCandidates(Json::arrayValue);
+        Json::Value node_results(Json::objectValue);
+        node_results["v"] = query_->numberer_.NumberToValue(i);
+        Json::Value node_candidate(Json::arrayValue);
         // Take only the top-n candidates to the response
         for (size_t j = 0; j < scored_candidates.size() && j < (size_t)((unsigned)n) ; j++) {
           Json::Value obj(Json::objectValue);
           obj["label"] = label_set_->GetLabelName(scored_candidates[j].first);
           obj["score"] = scored_candidates[j].second;
-          nodeCandidates.append(obj);
+          node_candidate.append(obj);
         }
-        nodeResults["candidates"] = nodeCandidates;
-        response->append(nodeResults);
+        node_results["candidates"] = node_candidate;
+        response->append(node_results);
       }
     }
   }

--- a/src/inference/inference.h
+++ b/src/inference/inference.h
@@ -70,7 +70,7 @@ public:
   virtual void ToJSON(Json::Value* assignment) const = 0;
 
   virtual void GetCandidates(
-      Nice2Inference& inference,
+      Nice2Inference* inference,
       const int n,
       Json::Value* response) = 0;
 

--- a/src/inference/inference.h
+++ b/src/inference/inference.h
@@ -54,6 +54,8 @@ struct SingleLabelErrorStats {
   std::mutex lock;
 };
 
+// Forward declaration
+class Nice2Inference;
 
 // Assigned results for the query (including the pre-assigned values).
 class Nice2Assignment {
@@ -66,6 +68,11 @@ public:
 
   virtual void FromJSON(const Json::Value& assignment) = 0;
   virtual void ToJSON(Json::Value* assignment) const = 0;
+
+  virtual void GetCandidates(
+      Nice2Inference& inference,
+      const int n,
+      Json::Value* response) = 0;
 
   // Deletes all labels that must be inferred (does not affect the given known labels).
   virtual void ClearInferredAssignment() = 0;

--- a/src/server/nice2server.cpp
+++ b/src/server/nice2server.cpp
@@ -125,11 +125,11 @@ public:
 
   void nbest(const Json::Value& request, Json::Value& response)
   {
-    int n = request["n"].asInt();
+    const int n = request["n"].asInt();
     VLOG(3) << request.toStyledString();
     verifyVersion(request);
 
-    const Json::Value shouldInferParam = request["infer"];
+    const Json::Value& shouldInferParam = request["infer"];
     // If infer parameter was not provided - set should infer to "false" by default
     bool shouldInfer = false;
     if (shouldInferParam != Json::Value::null) {
@@ -143,7 +143,7 @@ public:
     if (shouldInfer) {
       inference_.MapInference(query.get(), assignment.get());
     }
-    assignment->GetCandidates(inference_, n, &response);
+    assignment->GetCandidates(&inference_, n, &response);
 
     MaybeLogQuery("nbest", request, response);
   }

--- a/src/server/nice2server.cpp
+++ b/src/server/nice2server.cpp
@@ -125,15 +125,25 @@ public:
 
   void nbest(const Json::Value& request, Json::Value& response)
   {
-    // int n = request["n"].asInt();
+    int n = request["n"].asInt();
     VLOG(3) << request.toStyledString();
     verifyVersion(request);
+
+    const Json::Value shouldInferParam = request["infer"];
+    // If infer parameter was not provided - set should infer to "false" by default
+    bool shouldInfer = false;
+    if (shouldInferParam != Json::Value::null) {
+      shouldInfer = shouldInferParam.asBool();
+    }
+
     std::unique_ptr<Nice2Query> query(inference_.CreateQuery());
     query->FromJSON(request["query"]);
     std::unique_ptr<Nice2Assignment> assignment(inference_.CreateAssignment(query.get()));
     assignment->FromJSON(request["assign"]);
-    inference_.MapInference(query.get(), assignment.get());
-    assignment->ToJSON(&response);
+    if (shouldInfer) {
+      inference_.MapInference(query.get(), assignment.get());
+    }
+    assignment->GetCandidates(inference_, n, &response);
 
     MaybeLogQuery("nbest", request, response);
   }


### PR DESCRIPTION
- Changing the "nbest" API to return the n-best candidates for each node in the query (the previous implementation was the same as "infer").
- The calculation is done for each node separately, by fixing the labels of all the other nodes except for the current node, getting candidates for this node, sorting them descendingly according to their score, and taking the top n.
- The meaning is - given the others labels, what are the top candidates for the current node.
- Added an option whether to perform MAP inference or not before calculating the candidates.
- This API can be useful in cases where there are several semantically similar options (like "count", "count", "totalCount", "cnt" etc.), and we are running automatic accuracy evaluations, and we don't want to count a prediction as totally-incorrect, in case that the correct prediction is not first, but is in the top-n candidates.
- I would be happy if @vraychev could verify that I did not make any mistakes.

Thanks
