### PR TITLE
Use invalid names list in nbest

### DIFF
--- a/src/inference/graph_inference.cpp
+++ b/src/inference/graph_inference.cpp
@@ -365,6 +365,7 @@ public:
     for (size_t i = 0; i < candidates.size() ; i++) {
       int candidate = candidates[i];
       nodea.label = candidate;
+	  if (!graphInference.label_checker_.IsLabelValid(candidate)) continue;
       double score = GetNodeScore(*graphInference, node);
       scored_candidates->push_back(std::pair<int, double>(candidate, score));
     }


### PR DESCRIPTION
It seems that a name validation test is missing through nbest flow.
I added a label_checker call in GetCandidatesForNode, which is nbest-only method.

Best,
Meital
