### PR TITLE
Fix the build when using Apple's clang

### DIFF
--- a/util/zstream/strict_fstream.h
+++ b/util/zstream/strict_fstream.h
@@ -34,7 +34,7 @@ static std::string strerror()
     {
         buff = "Unknown error";
     }
-#elif (_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE
+#elif (__APPLE__ || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE))
 // XSI-compliant strerror_r()
     if (strerror_r(errno, &buff[0], buff.size()) != 0)
     {


### PR DESCRIPTION
Apple has the POSIX-compliant version of `strerror_r()` as per the man page:
```
int strerror_r(int errnum, char *strerrbuf, size_t buflen);
```

Without this change, building the project using `bazel build //...` fails with this error message:
```
ERROR: /Users/dineshbolkensteyn/Desktop/projects/Nice2Predict/util/recordio/BUILD:1:1: C++ compilation of rule '//util/recordio:single_proto' failed (Exit 1).
In file included from util/recordio/single_proto.cpp:11:
In file included from ./util/zstream/zstream.h:18:
./util/zstream/strict_fstream.h:46:36: error: cannot initialize a parameter of type 'const char *' with an lvalue of type 'int'
    std::string tmp(p, std::strlen(p));
```

Note that, while this PR fixes this particular issue, I do not know for sure if it is the best/right fix to apply.