### PR TITLE
remove stack limit for training debin

### DIFF
--- a/json/jsoncpp.cpp
+++ b/json/jsoncpp.cpp
@@ -352,7 +352,7 @@ bool Reader::readValue() {
   // But this deprecated class has a security problem: Bad input can
   // cause a seg-fault. This seems like a fair, binary-compatible way
   // to prevent the problem.
-  if (stackDepth_g >= stackLimit_g) throwRuntimeError("Exceeded stackLimit in readValue().");
+  // if (stackDepth_g >= stackLimit_g) throwRuntimeError("Exceeded stackLimit in readValue().");
   ++stackDepth_g;
 
   Token token;
@@ -1279,7 +1279,7 @@ bool OurReader::parse(const char* beginDoc,
 }
 
 bool OurReader::readValue() {
-  if (stackDepth_ >= features_.stackLimit_) throwRuntimeError("Exceeded stackLimit in readValue().");
+  // if (stackDepth_ >= features_.stackLimit_) throwRuntimeError("Exceeded stackLimit in readValue().");
   ++stackDepth_;
   Token token;
   skipCommentTokens(token);


### PR DESCRIPTION
When running `train_json` for debin, it gives `Exceeded stackLimit in readValue().` error.

This PR comments out the lines for raising the error and make it run for now