### PR TITLE
include cmath necessary for std::pow (tested)

### DIFF
--- a/n2p/training/train_internal.h
+++ b/n2p/training/train_internal.h
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <string>
 #include <fstream>
 #include <functional>


### PR DESCRIPTION
ERROR: Nice2Predict/n2p/training/BUILD:15:1: C++ compilation of rule '//n2p/training:train_json' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -B/usr/bin -B/usr/bin -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 102 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
In file included from n2p/training/train_json.cpp:26:0:
n2p/training/train_internal.h: In function 'void TrainPL(RecordInput<T>*, GraphInference*, int, double, Adapter<InputType>&)':
n2p/training/train_internal.h:134:24: error: there are no arguments to 'pow' that depend on a template parameter, so a declaration of 'pow' must be available [-fpermissive]
       learning_rate /= pow(pass + 1, 0.5);